### PR TITLE
feat(base): add ad dismissal utility and integrate BasePage into Logi…

### DIFF
--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -10,6 +10,25 @@ class BasePage:
         self.user_dropdown_toggle = page.locator("#navbarDropdown")
         self.logout_link = page.locator("#logout")
 
+    def dismiss_any_ads(self, timeout: float = 2000) -> None:
+        """
+        Attempt to dismiss intersitial ads if present.
+        Runs quickly and silently if no ad is found.
+        """
+        try:
+            ad_container = self.page.locator("#card:has(.creative)")
+            if not ad_container.is_visible(timeout=500):
+                return
+
+            close_button = ad_container.get_by_role("button", name="Close ad").or_(
+                ad_container.locator("#dismiss-button")
+            )
+            if close_button.is_visible(timeout=500):
+                close_button.click(timeout=500)
+                ad_container.wait_for(state="hidden", timeout=2000)
+        except TimeoutError:
+            pass
+
     def logout(self) -> None:
         """Log out the current user via the global navbar."""
         self.user_dropdown_toggle.click()

--- a/pages/login_page.py
+++ b/pages/login_page.py
@@ -1,14 +1,16 @@
 # pages/login_page.py
 from playwright.sync_api import Page
+from pages.base_page import BasePage
 
 
-class LoginPage:
+class LoginPage(BasePage):
     """Page Object for the ExpandTesting Bookstore Sign-In page."""
 
     URL = "https://practice.expandtesting.com/bookstore/user/signin"
 
     def __init__(self, page: Page) -> None:
-        self.page = page
+        super().__init__(page)
+
         self.email_input = page.get_by_placeholder("Enter your email...")
         self.password_input = page.get_by_placeholder("Enter your password...")
         self.sign_in_button = page.get_by_role("button", name="Sign In")


### PR DESCRIPTION
feat(base): add ad dismissal utility and integrate BasePage into LoginPage

- Implemented `dismiss_any_ads()` in `BasePage` using resilient OR locator:
  `get_by_role("button", name="Close ad")` OR `#dismiss-button`
- Wrapped ad logic in try/except with short timeouts — safe for non-deterministic ads
- Updated `LoginPage` to inherit from `BasePage`
