### PR TITLE
conftest logic refactor

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,28 @@
+# conftest.py
+import pytest
+import json
+from playwright.sync_api import Page
+from pages.login_page import LoginPage
+from pages.base_page import BasePage
+
+
+@pytest.fixture(scope="session")
+def test_users() -> dict:
+    """Load test user credentials from JSON (read-only, session-scoped)."""
+    with open("test_data/test_users.json") as f:
+        return json.load(f)
+
+
+@pytest.fixture()
+def logged_in_page(page: Page, test_users: dict) -> BasePage:
+    """
+    Returns a BasePage in a logged-in state.
+    Waits for post-login redirect to ensure stable state.
+    """
+    user = test_users["profile1"]
+    login_page = LoginPage(page)
+    login_page.load()
+    login_page.login(user["email"], user["password"])
+
+    page.wait_for_url("**/profile", timeout=10000)
+    return BasePage(page)

--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -34,6 +34,12 @@ class BasePage:
         except TimeoutError:
             pass
 
+    def is_logged_in(self) -> bool:
+        """
+        Returns True if user dropdown is present (logged in), False otherwise.
+        """
+        return self.user_dropdown_toggle.is_visible(timeout=1000)
+
     def logout(self) -> None:
         """Log out the current user via the global navbar."""
         self.user_dropdown_toggle.click()

--- a/pages/login_page.py
+++ b/pages/login_page.py
@@ -11,9 +11,14 @@ class LoginPage(BasePage):
     def __init__(self, page: Page) -> None:
         super().__init__(page)
 
-        self.email_input = page.get_by_placeholder("Enter your email...")
-        self.password_input = page.get_by_placeholder("Enter your password...")
-        self.sign_in_button = page.get_by_role("button", name="Sign In")
+        login_form = (
+            self.page.locator("form")
+            .filter(has=self.page.locator("#email"))
+            .filter(has=self.page.locator("#password"))
+        )
+        self.email_input = login_form.locator("#email")
+        self.password_input = login_form.locator("#password")
+        self.sign_in_button = login_form.locator("button[type='submit']")
 
     def load(self) -> None:
         """Navigate to the login page."""
@@ -26,9 +31,10 @@ class LoginPage(BasePage):
         self.sign_in_button.click()
 
     @property
-    def missing_credentials_error(self):
-        return self.page.get_by_text("Missing credentials")
-
-    @property
-    def invalid_email_error(self):
-        return self.page.get_by_text("Invalid email address")
+    def credentials_error_message(self):
+        """
+        Locator for the universal error banner (id='flash')
+        Use expect(...).to_be_visible() to check if any error is shown.
+        Use .text_content() or inner_text() to read the message.
+        """
+        return self.page.locator("#flash.alert.alert-danger")

--- a/tests/smoke/test_base_page.py
+++ b/tests/smoke/test_base_page.py
@@ -1,0 +1,8 @@
+# tests/smoke/test_base_page.py
+from pages.base_page import BasePage
+
+
+def test_logout(logged_in_page: BasePage) -> None:
+    assert logged_in_page.is_logged_in()
+    logged_in_page.logout()
+    assert not logged_in_page.is_logged_in()

--- a/tests/smoke/test_login_page.py
+++ b/tests/smoke/test_login_page.py
@@ -1,35 +1,34 @@
 # tests/smoke/test_login_page.py
-import pytest
 from playwright.sync_api import Page, expect
 from pages.login_page import LoginPage
-import json
 
 
-@pytest.fixture(scope="module")
-def test_users() -> dict:
-    with open("test_data/test_users.json") as f:
-        return json.load(f)
-
-
-def test_login_page_invalid_creds(page: Page) -> None:
+def test_login_rejects_empty_credentials(page: Page) -> None:
+    """Smoke: Login form shows error when both fields are empty."""
     login_page = LoginPage(page)
     login_page.load()
-
-    # Test empty creds
     login_page.login("", "")
     expect(login_page.credentials_error_message).to_be_visible()
+    # Optional: assert message content if critical
+    # assert "Missing credentials" in login_page.input_error_banner.text_content()
 
-    # Test Invalid creds
-    login_page.login("dawsa", "awd")
+
+def test_login_rejects_invalid_credentials(page: Page) -> None:
+    """Smoke: Login form shows error for malformed email and short password."""
+    login_page = LoginPage(page)
+    login_page.load()
+    login_page.login("not-an-email", "123")  # clearly invalid
     expect(login_page.credentials_error_message).to_be_visible()
 
 
-def test_login_page_correct_creds(page: Page, test_users: dict) -> None:
+def test_login_success_with_valid_credentials(page: Page, test_users: dict) -> None:
+    """Smoke: Valid credentials redirect to profile page."""
     login_page = LoginPage(page)
     login_page.load()
 
     user = test_users["profile1"]
     login_page.login(user["email"], user["password"])
+
     page.wait_for_url("**/profile")
     expect(page.get_by_role("heading", name="Profile")).to_be_visible()
     expect(page.get_by_role("heading", name="My Orders")).to_be_visible()

--- a/tests/smoke/test_login_page.py
+++ b/tests/smoke/test_login_page.py
@@ -17,11 +17,11 @@ def test_login_page_invalid_creds(page: Page) -> None:
 
     # Test empty creds
     login_page.login("", "")
-    expect(login_page.missing_credentials_error).to_be_visible()
+    expect(login_page.credentials_error_message).to_be_visible()
 
     # Test Invalid creds
     login_page.login("dawsa", "awd")
-    expect(login_page.invalid_email_error).to_be_visible()
+    expect(login_page.credentials_error_message).to_be_visible()
 
 
 def test_login_page_correct_creds(page: Page, test_users: dict) -> None:


### PR DESCRIPTION
feat(auth): implement login state detection and refactor smoke tests

- Added `is_logged_in()` method to `BasePage` using `#navbarDropdown` visibility  
- Created `conftest.py` with shared fixtures:  
  • `test_users` (session-scoped JSON loader)  
  • `logged_in_page` (function-scoped authenticated context)  
- Refactored login smoke tests to use fixtures and universal error banner  
- Added base page smoke test for logout flow  
- Removed hardcoded credentials and duplicated login logic  
- Ensured all smoke tests are POM-compliant and CI-safe