### PR TITLE
feat(checkout): add checkout and profile pages with smoke test

### DIFF
--- a/pages/checkout_page.py
+++ b/pages/checkout_page.py
@@ -1,0 +1,59 @@
+# pages.checkout_page.py
+from playwright.sync_api import Page
+from pages.base_page import BasePage
+
+
+class CheckoutPage(BasePage):
+    """Page Object for the ExpandTesting Bookstore Checkout page."""
+
+    URL = "https://practice.expandtesting.com/bookstore/checkout"
+
+    def __init__(self, page: Page) -> None:
+        super().__init__(page)
+
+        # Billing section
+        self.name_input = self.page.locator("#name")
+        self.address_input = self.page.locator("#address")
+
+        # Card section
+        self.card_name_input = self.page.locator("#card-name")
+        self.card_number_input = self.page.locator("#card-number")
+        self.card_expiry_month_input = self.page.locator("#card-expiry-month")
+        self.card_expiry_year_input = self.page.locator("#card-expiry-year")
+        self.card_cvc_input = self.page.locator("#card-cvc")
+
+        # Submit button
+        self.purchase_button = self.page.get_by_test_id("purchase")
+
+    def load(self) -> None:
+        """Navigate to the checkout page."""
+        self._safe_goto(self.URL)
+
+    def fill_and_submit(
+        self,
+        name: str,
+        address: str,
+        card_name: str,
+        card_number: str,
+        exp_month: int,
+        exp_year: int,
+        cvc: str,
+    ) -> None:
+        """
+        Fill all billing and card fields and submit the purchase form.
+        Waits for DOM content to load after submission.
+        """
+        # Fill billing details
+        self.name_input.fill(name)
+        self.address_input.fill(address)
+
+        # Fill card details
+        self.card_name_input.fill(card_name)
+        self.card_number_input.fill(card_number)
+        self.card_expiry_month_input.fill(str(exp_month))
+        self.card_expiry_year_input.fill(str(exp_year))
+        self.card_cvc_input.fill(cvc)
+
+        # Submit form
+        self.purchase_button.click()
+        self.page.wait_for_load_state("domcontentloaded")

--- a/pages/profile_page.py
+++ b/pages/profile_page.py
@@ -1,0 +1,22 @@
+# pages/profile_page.py
+from playwright.sync_api import Page
+from pages.base_page import BasePage
+
+
+class ProfilePage(BasePage):
+    """Page Object for the user Profile page with order history."""
+
+    URL = "https://practice.expandtesting.com/bookstore/user/profile"
+
+    def __init__(self, page: Page) -> None:
+        super().__init__(page)
+
+        self.order_confirmation_banner = self.page.locator("#flash.alert.alert-success")
+
+    def load(self) -> None:
+        """Navigate to the profile page."""
+        self._safe_goto(self.URL)
+
+    def is_order_confirmation_visible(self) -> bool:
+        """Check if the order confirmation banner is visible."""
+        return self.order_confirmation_banner.is_visible(timeout=5000)

--- a/test_data/test_users.json
+++ b/test_data/test_users.json
@@ -1,6 +1,16 @@
 {
   "profile1": {
     "email": "lolggwp228@gmail.com",
-    "password": "password123"
+    "password": "password123",
+    "billing": {
+      "name": "Test User",
+      "address": "123 Test Street, Test City"
+    },
+    "payment": {
+      "card_number": "4242424242424242",
+      "exp_month": 12,
+      "exp_year": 2030,
+      "cvc": "123"
+    }
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+# tests/conftest.py
+import re
+import pytest
+from playwright.sync_api import Page, Route
+
+AD_DOMAINS = [
+    "enshrouded.com",
+    "googleads.g.doubleclick.net",
+    "pagead2.googlesyndication.com",
+]
+
+
+def handle_route(route: Route):
+    """Intercept and block requests to ad domains."""
+    if any(re.search(domain, route.request.url) for domain in AD_DOMAINS):
+        return route.abort()
+    return route.continue_()
+
+
+@pytest.fixture
+def page(page: Page):
+    """
+    Override the default Playwright page fixture to block ads.
+    """
+    page.route("**/*", handle_route)
+    yield page

--- a/tests/smoke/test_checkout_page.py
+++ b/tests/smoke/test_checkout_page.py
@@ -1,0 +1,41 @@
+# tests/smoke/test_checkout_page.py
+from pages.home_page import HomePage
+from pages.cart_page import CartPage
+from pages.checkout_page import CheckoutPage
+from pages.profile_page import ProfilePage
+from pages.base_page import BasePage
+
+
+def test_checkout_smoke(logged_in_page: BasePage, test_users: dict) -> None:
+    """
+    Smoke test for the full authenticated purchase journey.
+    """
+    page = logged_in_page.page
+
+    home_page = HomePage(page)
+    home_page.load()
+    home_page.add_book_to_cart_by_index(0)
+    page.wait_for_load_state("domcontentloaded")
+    assert home_page.read_cart_count() == 1
+
+    cart_page = CartPage(page)
+    cart_page.load()
+    cart_page.proceed_to_checkout()
+
+    user = test_users["profile1"]
+    checkout_page = CheckoutPage(page)
+
+    checkout_page.fill_and_submit(
+        name=user["billing"]["name"],
+        address=user["billing"]["address"],
+        card_name="Test Cardholder",
+        card_number=user["payment"]["card_number"],
+        exp_month=user["payment"]["exp_month"],
+        exp_year=user["payment"]["exp_year"],
+        cvc=user["payment"]["cvc"],
+    )
+
+    page.wait_for_url("**/profile")
+
+    profile_page = ProfilePage(page)
+    assert profile_page.is_order_confirmation_visible()


### PR DESCRIPTION
Implements the Page Object Models for the Checkout and Profile pages. Adds an end-to-end smoke test to validate the checkout process up to the order confirmation step.

- **New Page Objects:**
  - `pages/checkout_page.py`: Encapsulates locators and actions for filling billing/payment details.
  - `pages/profile_page.py`: Handles verification of the post-purchase order confirmation.

- **New Smoke Test:**
  - `tests/smoke/test_checkout_page.py`: Validates the journey from adding an item to the cart through to successful checkout.

- **Test Stabilization:**
  - Added a network-level ad blocker in a new `tests/conftest.py` to prevent ad redirects from causing test failures.
  - Updated `test_users.json` with the necessary mock credit card data for the test.