### PR TITLE
feat: add pytest markers and update README for test organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This isn't just a collection of test scripts; it's a demonstration of a professi
 | **CI/CD Pipeline** | A GitHub Actions workflow runs on every push and PR, executing the full E2E suite in parallel across Chromium and Firefox. It includes linting (`ruff`) and type-checking (`mypy`) gates.                                                                                             |
 | **Observability** | On test failure, the CI pipeline automatically uploads **video recordings**, **Playwright traces**, and **screenshots** as artifacts, enabling rapid, precise debugging without needing to re-run locally.                                                                          |
 | **Ad & Tracker Blocking** | A layered defense combines network-level request blocking with DOM-level ad dismissal to create a stable, noise-free test environment.                                                                                                                                                      |
+| **Marker-Driven Suites** | All tests are tagged with pytest markers (`smoke`, `ui`, `api`, `e2e`, `bookstore`, `notes`) so CI can run targeted suites and developers can slice the matrix locally with a single flag. |
 
 ---
 
@@ -72,6 +73,13 @@ playwright install --with-deps
 ```bash
 # Run all tests in parallel (headless)
 pytest tests/ -v -n auto
+
+# Run only smoke checks (bookstore UI + notes API)
+pytest -m "smoke"
+
+# Focus on a specific surface
+pytest -m "bookstore and ui"
+pytest -m "notes and api"
 
 # Run tests in a specific file (headed, for debugging)
 pytest tests/test_purchase_journey.py --headed

--- a/bookstore/tests/smoke/test_base_page.py
+++ b/bookstore/tests/smoke/test_base_page.py
@@ -1,7 +1,11 @@
 # tests/smoke/test_base_page.py
+import pytest
 from bookstore.pages.base_page import BasePage
 
 
+@pytest.mark.bookstore
+@pytest.mark.ui
+@pytest.mark.smoke
 def test_logout(logged_in_page: BasePage) -> None:
     assert logged_in_page.is_logged_in()
     logged_in_page.logout()

--- a/bookstore/tests/smoke/test_cart_page.py
+++ b/bookstore/tests/smoke/test_cart_page.py
@@ -1,9 +1,13 @@
 # tests/smoke/test_cart_page.py
+import pytest
 from playwright.sync_api import Page
 from bookstore.pages.cart_page import CartPage
 from bookstore.pages.home_page import HomePage
 
 
+@pytest.mark.bookstore
+@pytest.mark.ui
+@pytest.mark.smoke
 def test_cart_is_empty(page: Page) -> None:
     cart_page = CartPage(page)
     cart_page.load()
@@ -11,6 +15,9 @@ def test_cart_is_empty(page: Page) -> None:
     assert cart_page.is_cart_empty()
 
 
+@pytest.mark.bookstore
+@pytest.mark.ui
+@pytest.mark.smoke
 def test_can_remove_cart_item(page: Page) -> None:
     home_page = HomePage(page)
     home_page.load()

--- a/bookstore/tests/smoke/test_checkout_page.py
+++ b/bookstore/tests/smoke/test_checkout_page.py
@@ -1,4 +1,5 @@
 # tests/smoke/test_checkout_page.py
+import pytest
 from bookstore.pages.home_page import HomePage
 from bookstore.pages.cart_page import CartPage
 from bookstore.pages.checkout_page import CheckoutPage
@@ -7,6 +8,10 @@ from bookstore.pages.base_page import BasePage
 from playwright.sync_api import expect
 
 
+@pytest.mark.bookstore
+@pytest.mark.ui
+@pytest.mark.smoke
+@pytest.mark.e2e
 def test_checkout_smoke(logged_in_page: BasePage, test_users: dict) -> None:
     """
     Smoke test for the full authenticated purchase journey.

--- a/bookstore/tests/smoke/test_home_page.py
+++ b/bookstore/tests/smoke/test_home_page.py
@@ -1,8 +1,12 @@
 # tests/smoke/test_home_page.py
+import pytest
 from playwright.sync_api import Page, expect
 from bookstore.pages.home_page import HomePage
 
 
+@pytest.mark.bookstore
+@pytest.mark.ui
+@pytest.mark.smoke
 def test_search_bar(page: Page) -> None:
     home_page = HomePage(page)
     home_page.load()
@@ -10,6 +14,9 @@ def test_search_bar(page: Page) -> None:
     expect(home_page.book_titles).to_have_count(1)
 
 
+@pytest.mark.bookstore
+@pytest.mark.ui
+@pytest.mark.smoke
 def test_first_book_to_cart_updates_badge(page: Page) -> None:
     home_page = HomePage(page)
     home_page.load()

--- a/bookstore/tests/smoke/test_login_page.py
+++ b/bookstore/tests/smoke/test_login_page.py
@@ -1,8 +1,12 @@
 # tests/smoke/test_login_page.py
+import pytest
 from playwright.sync_api import Page, expect
 from bookstore.pages.login_page import LoginPage
 
 
+@pytest.mark.bookstore
+@pytest.mark.ui
+@pytest.mark.smoke
 def test_login_rejects_empty_credentials(page: Page) -> None:
     """Smoke: Login form shows error when both fields are empty."""
     login_page = LoginPage(page)
@@ -12,6 +16,9 @@ def test_login_rejects_empty_credentials(page: Page) -> None:
     expect(login_page.credentials_error_message).to_be_visible(timeout=10000)
 
 
+@pytest.mark.bookstore
+@pytest.mark.ui
+@pytest.mark.smoke
 def test_login_rejects_invalid_credentials(page: Page) -> None:
     """Smoke: Login form shows error for malformed email and short password."""
     login_page = LoginPage(page)
@@ -21,6 +28,9 @@ def test_login_rejects_invalid_credentials(page: Page) -> None:
     expect(login_page.credentials_error_message).to_be_visible(timeout=10000)
 
 
+@pytest.mark.bookstore
+@pytest.mark.ui
+@pytest.mark.smoke
 def test_login_success_with_valid_credentials(page: Page, test_users: dict) -> None:
     """Smoke: Valid credentials redirect to profile page."""
     login_page = LoginPage(page)

--- a/bookstore/tests/smoke/test_placeholder.py
+++ b/bookstore/tests/smoke/test_placeholder.py
@@ -1,4 +1,8 @@
 # tests/smoke/test_placeholder.py
+import pytest
+
+
+@pytest.mark.smoke
 def test_placeholder():
     """CI smoke test — will be replaced by real E2E."""
     assert True

--- a/bookstore/tests/test_purchase_journey.py
+++ b/bookstore/tests/test_purchase_journey.py
@@ -1,4 +1,5 @@
 # tests/ test_purchase_journey.py
+import pytest
 from bookstore.pages.home_page import HomePage
 from bookstore.pages.cart_page import CartPage
 from bookstore.pages.checkout_page import CheckoutPage
@@ -6,6 +7,9 @@ from bookstore.pages.profile_page import ProfilePage
 from playwright.sync_api import expect
 
 
+@pytest.mark.bookstore
+@pytest.mark.ui
+@pytest.mark.e2e
 def test_authenticated_purchase_journey(logged_in_page, test_users) -> None:
     """
     P0 E2E Full authenticated purchase flow.

--- a/notes/tests/smoke/test_create_note.py
+++ b/notes/tests/smoke/test_create_note.py
@@ -1,7 +1,11 @@
 # notes/tests/smoke/test_create_note.py
+import pytest
 from notes.helpers.api_client import ApiClient
 
 
+@pytest.mark.notes
+@pytest.mark.api
+@pytest.mark.smoke
 def test_create_note(api_client_auth: ApiClient) -> None:
     note_id: str | None = None
     try:

--- a/notes/tests/smoke/test_login.py
+++ b/notes/tests/smoke/test_login.py
@@ -1,8 +1,12 @@
 # notes/tests/smoke/test_login.py
+import pytest
 from notes.helpers.api_client import ApiClient
 from config import BASE_URL_API
 
 
+@pytest.mark.notes
+@pytest.mark.api
+@pytest.mark.smoke
 def test_login(test_users: dict) -> None:
     api_client = ApiClient(BASE_URL_API)
     user = test_users["profile1"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+markers =
+    smoke: High-value smoke checks suited for fast CI feedback.
+    e2e: Full end-to-end journeys covering critical user flows.
+    ui: Browser-based UI tests executed via Playwright.
+    api: API-level tests that call backend services directly.
+    bookstore: Tests targeting the ExpandTesting bookstore application.
+    notes: Tests targeting the ExpandTesting notes application.


### PR DESCRIPTION
Added shared marker registration in pytest.ini and tagged every bookstore and
  notes test with the relevant combinations (smoke, ui, api, e2e, bookstore,
  notes) so suites can be sliced cleanly in CI or locally. README now documents
  the marker-driven workflow and shows example invocations like pytest -m
  "smoke" and pytest -m "notes and api".
