### PR TITLE
feat: add support for multiple user profiles in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ pip install -r requirements.txt
 playwright install --with-deps
 ````
 
+### **2.1 Provide Test Credentials**
+The suite looks for credentials in the `TEST_USERS_JSON` environment variable or a local `shared/test_data/test_users.json` file (git-ignored). Profiles are keyed by name (e.g., `profile1`, `profile2`), and you can select one at runtime with `pytest --profile=<name>`. If no profile is specified, `profile1` is used by default.
+
 ### **3. Running Tests**
 
 ```bash
@@ -86,6 +89,9 @@ pytest tests/test_purchase_journey.py --headed
 
 # Run tests only in a specific browser
 pytest tests/ -v --browser firefox
+
+# Switch the active test user profile (defaults to profile1)
+pytest -k login --profile=profile2
 ```
 
 -----

--- a/bookstore/tests/smoke/test_checkout_page.py
+++ b/bookstore/tests/smoke/test_checkout_page.py
@@ -12,7 +12,9 @@ from playwright.sync_api import expect
 @pytest.mark.ui
 @pytest.mark.smoke
 @pytest.mark.e2e
-def test_checkout_smoke(logged_in_page: BasePage, test_users: dict) -> None:
+def test_checkout_smoke(
+    logged_in_page: BasePage, test_users: dict, profile_name: str
+) -> None:
     """
     Smoke test for the full authenticated purchase journey.
     """
@@ -27,7 +29,7 @@ def test_checkout_smoke(logged_in_page: BasePage, test_users: dict) -> None:
     cart_page.load()
     cart_page.proceed_to_checkout()
 
-    user = test_users["profile1"]
+    user = test_users[profile_name]
     checkout_page = CheckoutPage(page)
 
     checkout_page.fill_and_submit(

--- a/bookstore/tests/smoke/test_login_page.py
+++ b/bookstore/tests/smoke/test_login_page.py
@@ -31,12 +31,14 @@ def test_login_rejects_invalid_credentials(page: Page) -> None:
 @pytest.mark.bookstore
 @pytest.mark.ui
 @pytest.mark.smoke
-def test_login_success_with_valid_credentials(page: Page, test_users: dict) -> None:
+def test_login_success_with_valid_credentials(
+    page: Page, test_users: dict, profile_name: str
+) -> None:
     """Smoke: Valid credentials redirect to profile page."""
     login_page = LoginPage(page)
     login_page.load()
 
-    user = test_users["profile1"]
+    user = test_users[profile_name]
     login_page.login(user["email"], user["password"])
 
     page.wait_for_url("**/profile")

--- a/bookstore/tests/test_purchase_journey.py
+++ b/bookstore/tests/test_purchase_journey.py
@@ -10,7 +10,9 @@ from playwright.sync_api import expect
 @pytest.mark.bookstore
 @pytest.mark.ui
 @pytest.mark.e2e
-def test_authenticated_purchase_journey(logged_in_page, test_users) -> None:
+def test_authenticated_purchase_journey(
+    logged_in_page, test_users, profile_name: str
+) -> None:
     """
     P0 E2E Full authenticated purchase flow.
     Covers: search, add to cart, checkout, order confirmation.
@@ -34,7 +36,7 @@ def test_authenticated_purchase_journey(logged_in_page, test_users) -> None:
     cart_page.proceed_to_checkout()
 
     # Step 4: Fill and submit checkout form
-    user = test_users["profile1"]
+    user = test_users[profile_name]
     checkout_page = CheckoutPage(page)
     checkout_page.fill_and_submit(
         name=user["billing"]["name"],

--- a/notes/conftest.py
+++ b/notes/conftest.py
@@ -7,11 +7,9 @@ from config import BASE_URL_API
 @pytest.fixture(
     scope="function"
 )  # isolate auth/token per test; switch to session for speed if safe
-def api_client_auth(test_users: dict) -> ApiClient:
+def api_client_auth(test_users: dict, profile_name: str) -> ApiClient:
     """Create an API client for the notes API."""
     api_client = ApiClient(BASE_URL_API)
-    api_client.login_user(
-        email=test_users["profile1"]["email"],
-        password=test_users["profile1"]["password"],
-    )
+    user = test_users[profile_name]
+    api_client.login_user(email=user["email"], password=user["password"])
     return api_client

--- a/notes/tests/smoke/test_login.py
+++ b/notes/tests/smoke/test_login.py
@@ -7,9 +7,9 @@ from config import BASE_URL_API
 @pytest.mark.notes
 @pytest.mark.api
 @pytest.mark.smoke
-def test_login(test_users: dict) -> None:
+def test_login(test_users: dict, profile_name: str) -> None:
     api_client = ApiClient(BASE_URL_API)
-    user = test_users["profile1"]
+    user = test_users[profile_name]
     response = api_client.login_user(user["email"], user["password"])
 
     assert response["success"] is True, "Login successful"


### PR DESCRIPTION
- Introduced a custom CLI option `--profile` to select the test user profile at runtime, defaulting to `profile1`.
- Updated the `auth_file` fixture to use the selected profile for authentication.
- Modified relevant tests to utilize the selected profile, enhancing flexibility in testing different user scenarios.
- Updated README to document the new profile selection feature.