### PR TITLE
fix(tests): update URL wait conditions to use dynamic URL references

### DIFF
--- a/bookstore/tests/smoke/test_checkout_page.py
+++ b/bookstore/tests/smoke/test_checkout_page.py
@@ -44,7 +44,7 @@ def test_checkout_smoke(
     )
 
     # Wait for navigation to profile page
-    expect(page).to_have_url(re.compile(r".*/profile"), timeout=10_000)
+    expect(page).to_have_url(re.compile(f".*{ProfilePage.URL}"), timeout=10_000)
 
     profile_page = ProfilePage(page)
     expect(profile_page.order_confirmation_banner).to_be_visible(timeout=15000)

--- a/bookstore/tests/smoke/test_login_page.py
+++ b/bookstore/tests/smoke/test_login_page.py
@@ -2,6 +2,7 @@
 import pytest
 from playwright.sync_api import Page, expect
 from bookstore.pages.login_page import LoginPage
+from bookstore.pages.profile_page import ProfilePage
 
 
 @pytest.mark.bookstore
@@ -41,5 +42,5 @@ def test_login_success_with_valid_credentials(
     user = test_users[profile_name]
     login_page.login(user["email"], user["password"])
 
-    page.wait_for_url("**/profile")
+    page.wait_for_url(f"**{ProfilePage.URL}")
     expect(page.get_by_role("heading", name="Profile")).to_be_visible()

--- a/bookstore/tests/test_purchase_journey.py
+++ b/bookstore/tests/test_purchase_journey.py
@@ -34,7 +34,7 @@ def test_authenticated_purchase_journey(
     cart_page = CartPage(page)
     cart_page.load()
     cart_page.proceed_to_checkout()
-    page.wait_for_url("**/checkout")
+    page.wait_for_url(f"**{CheckoutPage.URL}")
 
     # Step 4: Fill and submit checkout form
     user = test_users[profile_name]


### PR DESCRIPTION
- Modified URL wait conditions in the purchase journey, checkout smoke, and login page tests to utilize dynamic references from the respective page classes.
- This change enhances test reliability by ensuring that the correct URLs are used, reducing potential false negatives in navigation checks.