### PR TITLE
fix(checkout): ensure Stripe is loaded before form submission

### DIFF
--- a/bookstore/conftest.py
+++ b/bookstore/conftest.py
@@ -31,7 +31,7 @@ def auth_file(browser: Browser, test_users: dict, profile_name: str) -> Path:
         login_page = LoginPage(page)
         login_page.load()
         login_page.login(user["email"], user["password"])
-        page.wait_for_url("**/profile", timeout=10_000)
+        page.wait_for_url("**/profile", timeout=15_000)
         page.context.storage_state(path=auth_path)
         page.close()
 

--- a/bookstore/pages/checkout_page.py
+++ b/bookstore/pages/checkout_page.py
@@ -54,5 +54,6 @@ class CheckoutPage(BasePage):
         self.card_expiry_year_input.fill(str(exp_year))
         self.card_cvc_input.fill(cvc)
 
+        self.page.wait_for_function("typeof Stripe !== 'undefined'")
         # Submit form
         self.purchase_button.click()

--- a/bookstore/tests/smoke/test_checkout_page.py
+++ b/bookstore/tests/smoke/test_checkout_page.py
@@ -36,13 +36,12 @@ def test_checkout_smoke(
     checkout_page.fill_and_submit(
         name=user["billing"]["name"],
         address=user["billing"]["address"],
-        card_name="Test Cardholder",
+        card_name=user["billing"]["name"],
         card_number=user["payment"]["card_number"],
         exp_month=user["payment"]["exp_month"],
         exp_year=user["payment"]["exp_year"],
         cvc=user["payment"]["cvc"],
     )
-
     # Wait for navigation to profile page
     expect(page).to_have_url(re.compile(f".*{ProfilePage.URL}"), timeout=10_000)
 


### PR DESCRIPTION
- Added a wait function to check for the Stripe library's availability before submitting the checkout form.
- Updated the test to use the user's billing name for the cardholder name instead of a hardcoded value, improving test accuracy.