### PR TITLE
Pin cache and artifact actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           cache-dependency-path: requirements.txt
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v4.0.0
         with:
           path: |
             ~/.cache/ms-playwright
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: bookstore-failure-artifacts-${{ matrix.browser }}
           path: |
@@ -106,7 +106,7 @@ jobs:
           cache-dependency-path: requirements.txt
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v4.0.0
         with:
           path: |
             ~/.cache/ms-playwright
@@ -153,7 +153,7 @@ jobs:
 
       - name: Upload failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: notes-parallel-failure-artifacts-${{ matrix.browser }}
           path: |
@@ -190,7 +190,7 @@ jobs:
           cache-dependency-path: requirements.txt
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v4.0.0
         with:
           path: |
             ~/.cache/ms-playwright
@@ -235,7 +235,7 @@ jobs:
 
       - name: Upload failure artifacts (${{ matrix.browser }})
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: notes-seq-failure-artifacts-${{ matrix.browser }}
           path: |
@@ -284,7 +284,7 @@ jobs:
 
       - name: Upload failure artifacts (notes-api)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: notes-api-failure-artifacts
           path: |
@@ -315,7 +315,7 @@ jobs:
           cache-dependency-path: requirements.txt
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v4.0.0
         with:
           path: |
             ~/.cache/ms-playwright
@@ -352,7 +352,7 @@ jobs:
 
       - name: Upload failure artifacts (hybrid)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: notes-hybrid-failure-artifacts-${{ matrix.browser }}
           path: |
@@ -380,7 +380,7 @@ jobs:
           cache-dependency-path: requirements.txt
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v4.0.0
         with:
           path: |
             ~/.cache/ms-playwright
@@ -425,7 +425,7 @@ jobs:
 
       - name: Upload failure artifacts (push bookstore)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: push-bookstore-failure-artifacts
           path: |
@@ -453,7 +453,7 @@ jobs:
           cache-dependency-path: requirements.txt
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v4.0.0
         with:
           path: |
             ~/.cache/ms-playwright
@@ -498,7 +498,7 @@ jobs:
 
       - name: Upload failure artifacts (push notes ui)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: push-notes-ui-failure-artifacts
           path: |
@@ -547,7 +547,7 @@ jobs:
 
       - name: Upload failure artifacts (push notes api)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: push-notes-api-failure-artifacts
           path: |


### PR DESCRIPTION
## Summary
- pin all cache steps to actions/cache@v4.0.0 to avoid deprecated runners
- pin artifact upload steps to actions/upload-artifact@v4.0.0 across workflows

## Testing
- Not run (CI workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921c4e40b148326a4d9f124058c1437)